### PR TITLE
Improve processing efficiency in check_parked.sh

### DIFF
--- a/scripts/check_parked.sh
+++ b/scripts/check_parked.sh
@@ -203,15 +203,15 @@ remove_parked() {
 
     # Strip subdomains from parked domains
     gawk '
-        # store lines from subdomains_to_remove as keys in array "dom"
-        NR==FNR { dom[$0]; next }
+        # store lines from subdomains_to_remove as keys in array "subdom"
+        NR==FNR { subdom[$0]; next }
         # process parked.tmp
         {
             # split current line by "." and store strings in array "arr"
             n=split($0,arr,".")
             # if "arr" has more than 1 element,
-            # and string in "dom" matches 1st element of array "arr", remove subdomain from the line
-            if (n>1 && arr[1] in dom) {
+            # and string in "subdom" matches 1st element of array "arr", remove subdomain from the line
+            if (n>1 && arr[1] in subdom) {
                 regex="^" arr[1] "."
                 sub(regex,"")
             }

--- a/scripts/check_parked.sh
+++ b/scripts/check_parked.sh
@@ -211,16 +211,11 @@ remove_parked() {
         {
             # split current line by "." and store strings in array "arr"
             n=split($0,arr,".")
-            # if "arr" has more than 1 element, loop over domains in array "dom"
-            if (n>1) {
-                for (d in dom) {
-                    # if string in "dom" matches 1st element of array "arr", remove subdomain from the line and break the loop
-                    if (match(arr[1], d)) {
-                        regex="^" d "."
-                        sub(regex,"")
-                        break
-                    }
-                }
+            # if "arr" has more than 1 element,
+            # and string in "dom" matches 1st element of array "arr", remove subdomain from the line
+            if (n>1 && arr[1] in dom) {
+                regex="^" arr[1] "."
+                sub(regex,"")
             }
             # print out the line
             print $0

--- a/scripts/check_parked.sh
+++ b/scripts/check_parked.sh
@@ -150,12 +150,16 @@ find_parked() {
         local count=1
     fi
 
+    # Count lines
+    local lines_cnt
+    lines_cnt="$(wc -l < "$1")"
+
     # Loop through domains
     while read -r domain; do
         if [[ "$track" == true ]]; then
             if (( count % 100 == 0 )); then
                 printf "[progress] Analyzed %s%% of domains\n" \
-                    "$(( count * 100 / $(wc -l < "$1") ))"
+                    "$(( count * 100 / lines_cnt ))"
             fi
 
             (( count++ ))


### PR DESCRIPTION
Hi, here you have 2 fairly simple modifications which should improve the efficiency:
- avoid creating a subshell in a loop (creating subshells is slow, so better to avoid them in loops)
- replace the slow builtin 'while read -r' loop + calls to 'sed -i' used to strip subdomains with awk script

Functionally this should work same as before, except somewhat faster.